### PR TITLE
Added Google Chrome instructions to README.md

### DIFF
--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -133,3 +133,5 @@
        ```
 
     6. Open up a web browser and navigate to https://localhost:PPPP.
+
+    7. If using Google Chrome, you may need to allow requests to localhost. Head to chrome://flags/#allow-insecure-localhost and enable the option "Allow invalid certficates for resources loaded from localhost."


### PR DESCRIPTION
I had to take this extra step in order to launch a jupyter notebook from Sverdrup and connect through localhost on my laptop